### PR TITLE
Added coloring for *.vdb files

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "contributes": {
         "languages": [{
             "id": "database",
-            "aliases": ["EPICS database", "DB"],
-            "extensions": [".db",".template"],
+            "aliases": ["EPICS database", "DB", "VDB"],
+            "extensions": [".db",, ".vdb", ".template"],
             "configuration": "./language-configuration.json"
         },
         {


### PR DESCRIPTION
VDB files are essentially DB files with extra comments at the end for telling the VDCT program where to position records on screen.

The extension intereprets and colors the VDB files correctly as is.