### PR TITLE
Update CHANGELOG with the recent pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## 0.0.11 - TBA
+
+- add MSI tool keywords: include, substitute
+- add field value enums: aoOif, menuOmsl, menuScan, calcoutOOPT, calcoutDOPT, fanoutSELM
+- add support for $(MACRO)
+- add record types: int64in, int64out, printf, lsi, lso
+- add fields: OCAL, OEVT, OOPT, MALM, DOPT, INDX, ALG, BALG, NSAM, SELM, SELN, SELL, SIZV, ODLY, FMT, INP0-INP9
+- improved highlighting of escaped quotation marks
+
 ## 0.0.10 - 2020-0-07
 
 - add `.iocsh` file to startup


### PR DESCRIPTION
This pull request contains information about changes introduced by the recent pull request (#27).

Since the version 0.0.10 which does not contain the pull request #27 was released already, I have added version 0.0.11 with unknown release date. Since I am using the extension intensively, I might add a modification here and there. Maybe, the version 0.0.11 could be scheduled for early October 2020. What do you think?